### PR TITLE
Update to intelMPI 2021.16

### DIFF
--- a/.github/workflows/install_vcpkg_packages.yml
+++ b/.github/workflows/install_vcpkg_packages.yml
@@ -16,8 +16,8 @@ jobs:
       VCPKG_OVERLAY_PORTS: ${{ github.workspace }}/../../build_base/framework-ci/vcpkg_overlays/${{ matrix.vcpkg_overlay }}
       VCPKG_DISABLE_METRICS: 1
       VCPKG_BUILD_DIR: '${{ github.workspace }}/../../build_base/framework-ci/vcpkg'
-      VCPKG_PREINSTALL_HASH_PACKAGE_NAME: '1.7.2-${{ matrix.full_name }}-${{ matrix.triplet }}'
-      VCPKG_PUSH_HASH_PACKAGE_NAME: '1.7.3-${{ matrix.full_name }}-${{ matrix.triplet }}'
+      VCPKG_PREINSTALL_HASH_PACKAGE_NAME: '1.8.0-${{ matrix.full_name }}-${{ matrix.triplet }}'
+      VCPKG_PUSH_HASH_PACKAGE_NAME: '1.8.1-${{ matrix.full_name }}-${{ matrix.triplet }}'
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_VERSION: '6.x'

--- a/.github/workflows/install_vcpkg_packages.yml
+++ b/.github/workflows/install_vcpkg_packages.yml
@@ -16,8 +16,8 @@ jobs:
       VCPKG_OVERLAY_PORTS: ${{ github.workspace }}/../../build_base/framework-ci/vcpkg_overlays/${{ matrix.vcpkg_overlay }}
       VCPKG_DISABLE_METRICS: 1
       VCPKG_BUILD_DIR: '${{ github.workspace }}/../../build_base/framework-ci/vcpkg'
-      VCPKG_PREINSTALL_HASH_PACKAGE_NAME: '1.8.0-${{ matrix.full_name }}-${{ matrix.triplet }}'
-      VCPKG_PUSH_HASH_PACKAGE_NAME: '1.8.1-${{ matrix.full_name }}-${{ matrix.triplet }}'
+      VCPKG_PREINSTALL_HASH_PACKAGE_NAME: '1.8.1-${{ matrix.full_name }}-${{ matrix.triplet }}'
+      VCPKG_PUSH_HASH_PACKAGE_NAME: '1.8.2-${{ matrix.full_name }}-${{ matrix.triplet }}'
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_CLI_TELEMETRY_OPTOUT: true
       DOTNET_VERSION: '6.x'
@@ -39,13 +39,13 @@ jobs:
             vcpkg_overlay: none
             # To run `nuget.exe` on non-Windows platforms, we must use `mono`.
             mono: 'mono'
-          # - os: 'ubuntu-24.04'
-          #   full_name: 'ubuntu-24.04'
-          #   triplet: 'x64-linux-dynamic'
-          #   nugetexe: /usr/local/bin/nuget.exe
-          #   vcpkg_overlay: none
-          #   # To run `nuget.exe` on non-Windows platforms, we must use `mono`.
-          #   mono: 'mono'
+          - os: 'ubuntu-24.04'
+            full_name: 'ubuntu-24.04'
+            triplet: 'x64-linux-dynamic'
+            nugetexe: /usr/local/bin/nuget.exe
+            vcpkg_overlay: none
+            # To run `nuget.exe` on non-Windows platforms, we must use `mono`.
+            mono: 'mono'
 
     steps:
 
@@ -61,6 +61,14 @@ jobs:
           ls -lart '${{ github.workspace }}'
           cd '${{ github.workspace }}' && mv _build docs nuget.config vcpkg vcpkg_overlays '${{ env.FRAMEWORKCI_ROOT_PATH }}'
           ls -lart '${{ env.FRAMEWORKCI_ROOT_PATH }}'
+
+      - name: Install mono
+        shell: 'bash'
+        # Mono is needed for 'ubuntu-24.04' because it is no longer installed on the runner
+        # WARNING: The installation has to be done after 'setup-dotnet'
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
+        run: |
+          sudo apt-get install -y mono-devel
 
       - name: Setup environment
         shell: 'bash'

--- a/.github/workflows/install_vcpkg_packages.yml
+++ b/.github/workflows/install_vcpkg_packages.yml
@@ -26,31 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: 'windows-2019'
-            full_name: 'windows-2019-msmpi'
-            triplet: x64-windows
-            nugetexe: nuget.exe
-            vcpkg_overlay: none
-            mono: ''
-          - os: 'windows-2019'
-            full_name: 'windows-2019-intelmpi'
-            triplet: x64-windows
-            nugetexe: nuget.exe
-            vcpkg_overlay: win32-intelmpi
-            mono: ''
           - os: 'windows-2022'
             full_name: 'windows-2022-intelmpi'
             triplet: x64-windows
             nugetexe: nuget.exe
             vcpkg_overlay: win32-intelmpi
             mono: ''
-          - os: 'ubuntu-20.04'
-            full_name: 'ubuntu-20.04'
-            triplet: 'x64-linux-dynamic'
-            nugetexe: /usr/local/bin/nuget.exe
-            vcpkg_overlay: none
-            # To run `nuget.exe` on non-Windows platforms, we must use `mono`.
-            mono: 'mono'
           - os: 'ubuntu-22.04'
             full_name: 'ubuntu-22.04'
             triplet: 'x64-linux-dynamic'

--- a/_build/download_intel_mpi_2021.bat
+++ b/_build/download_intel_mpi_2021.bat
@@ -1,6 +1,7 @@
-C:\msys64\usr\bin\wget.exe "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/e9f49ab3-babd-4753-a155-ceeb87e36674/intel-mpi-2021.14.1.8_offline.exe"
+rem C:\msys64\usr\bin\wget.exe "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/e9f49ab3-babd-4753-a155-ceeb87e36674/intel-mpi-2021.14.1.8_offline.exe"
+C:\msys64\usr\bin\wget.exe "https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c7b82926-172a-4943-8612-fcbc4625b17a/intel-mpi-2021.16.0.441_offline.exe"
 echo "Download finished"
-.\intel-mpi-2021.14.1.8_offline.exe -s -a --silent --eula=accept
+.\intel-mpi-2021.16.0.441_offline.exe -s -a --silent --eula=accept
 dir "C:\Program Files (x86)"
 dir "C:\Program Files (x86)\Intel"
 dir "C:\Program Files (x86)\Intel\OneAPI"

--- a/vcpkg_overlays/win32-intelmpi/intel-mpi/portfile.cmake
+++ b/vcpkg_overlays/win32-intelmpi/intel-mpi/portfile.cmake
@@ -106,6 +106,6 @@ endif()
 file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/mpi-wrapper.cmake" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 
 # Handle copyright
-# C:\Program Files (x86)\Intel\oneAPI\licensing\2025.0\licensing\2025.0
-file(COPY "${SDK_SOURCE_DIR}/licensing/2025.0/licensing/2025.0/license.htm" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+# C:\Program Files (x86)\Intel\oneAPI\licensing\2025.2\licensing\2025.2
+file(COPY "${SDK_SOURCE_DIR}/licensing/2025.2/licensing/2025.2/license.htm" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
 file(WRITE "${CURRENT_PACKAGES_DIR}/share/${PORT}/copyright" "See the accompanying 'licence.htm'")

--- a/vcpkg_overlays/win32-intelmpi/intel-mpi/portfile.cmake
+++ b/vcpkg_overlays/win32-intelmpi/intel-mpi/portfile.cmake
@@ -1,6 +1,6 @@
 # The last digit in the version is not used in the path
-# For example, use '2021.14' for version '2021.14.1'
-set(INTELMPI_VERSION "2021.14")
+# For example, use '2021.16' for version '2021.16.0'
+set(INTELMPI_VERSION "2021.16")
 set(SOURCE_PATH "${CURRENT_BUILDTREES_DIR}/src/intel-mpi-${INTELMPI_VERSION}")
 
 file(TO_NATIVE_PATH "C:/Program Files (x86)/Intel/oneAPI" SDK_SOURCE_DIR)


### PR DESCRIPTION
This version had a fix for a fatal error message in debug version of IntelMPI library.
